### PR TITLE
refactoring main resource classes and handles external binaries (FCREPO-2327)

### DIFF
--- a/verify.py
+++ b/verify.py
@@ -36,50 +36,25 @@ EXT_MAP = {'application/ld+json':   '.json',
 # HELPER FUNCTIONS
 #============================================================================
 
-def is_binary(node, auth, logger):
-    '''Using link headers, determine whether a resource is rdf or non-rdf.'''
-    response = requests.head(url=node, auth=auth)
-    if response.status_code == 200:
-        if response.links['type']['url'] == \
-            'http://www.w3.org/ns/ldp#NonRDFSource':
-            return True
-        else:
-            return False
-    else:
-        # this should probably check for different errors (like 410 - gone, etc.)
-        logger.error("Error communicating with repository. Response: {0} for node {1}".format(
-            response.status_code, node))
-        sys.exit(1)
-
-def calculate_sha1(filepath):
-    '''Given a file or stream, return the sha1 checksum.'''
-    with open(filepath, 'rb') as f:
-        sh = sha1()
-        while True:
-            data = f.read(8192)
-            if not data:
-                break
-            sh.update(data)
-    return sh.hexdigest()
-
 def get_child_nodes(node, auth, logger):
     '''Get the children based on LDP containment.'''
-    if is_binary(node, auth, logger):
-        metadata = [node + "/fcr:metadata"]
-        return metadata
-    else:
-        response = requests.get(node, auth=auth)
-        if response.status_code == 200:
-            graph = Graph()
-            graph.parse(data=response.text, format="text/turtle")
+    print('checking children')
+    head = requests.head(url=node, auth=auth)
+    if head.status_code == 200 or head.status_code == 307:
+        if head.links["type"]["url"] == 'http://www.w3.org/ns/ldp#NonRDFSource':
+            metadata = [node + "/fcr:metadata"]
+            return metadata
+        else:
+            response = requests.get(url=node, auth=auth)
+            graph = Graph().parse(data=response.text, format="text/turtle")
             predicate = URIRef('http://www.w3.org/ns/ldp#contains')
             children = [str(obj) for obj in graph.objects(
                             subject=None, predicate=predicate
                             )]
             return children
-        else:
-            logger.error("Error communicating with repository.")
-            sys.exit(1)
+    else:
+        logger.error("Error communicating with repository.")
+        sys.exit(1)
 
 def get_directory_contents(localpath):
     '''Get the children based on the directory hierarchy.'''
@@ -191,79 +166,122 @@ class LocalWalker(Walker):
 # MAIN RESOURCE CLASS
 #============================================================================
 
-class Resource():
-    '''Object representing any resource, either local or in fcrepo.'''
+class Resource(object):
+    '''Common aspects of any resource, either local or in fcrepo.'''
     def __init__(self, inputpath, config, logger):
-        self.logger = logger
+        self.config = config
         self.origpath = inputpath
+        self.logger = logger
 
-        # handle fcrepo resources
-        if self.origpath.startswith(config.repo):
-            self.location = 'fcrepo'
-            self.relpath = urlparse(self.origpath).path.rstrip('/')
+#============================================================================
+# FEDORA RESOURCE CLASS
+#============================================================================
 
-            # non-RDF sources
-            if is_binary(self.origpath, config.auth, self.logger):
-                self.type = 'binary'
-                self.metadata = self.origpath + '/fcr:metadata'
-                self.destpath = quote((config.dir + self.relpath + '.binary'))
-                response = requests.get(self.metadata, auth=config.auth)
-
-                # filename as stored in fcrepo
-                fn_match = search(r'ebucore:filename \"(.+?)\"', response.text)
-                self.filename = fn_match.group(1) if fn_match else ""
-
-                # sha1 checksum as stored in fcrepo
-                sh_match = search(
-                    r'premis:hasMessageDigest <urn:sha1:(.+?)>', response.text
+class FedoraResource(Resource):
+    '''Properties and methods for a resource in a Fedora repository.'''
+    def __init__(self, inputpath, config, logger):
+        Resource.__init__(self, inputpath, config, logger)
+        self.location = "fedora"
+        self.relpath = urlparse(self.origpath).path.rstrip('/')
+        self.fetch_headers()
+        if self.is_binary():
+            self.type = "binary"
+            if self.external:
+                self.destpath = quote(
+                    (self.config.dir + self.relpath + '.external')
                     )
-                self.sha1 = sh_match.group(1) if sh_match else ""
-
-            # RDF sources
             else:
-                self.type = 'rdf'
-                self.destpath = quote((config.dir + self.relpath + config.ext))
-                response = requests.get(self.origpath, auth=config.auth)
-                if response.status_code == 200:
-                    self.graph = Graph().parse(data=response.text, format="text/turtle")
-
-        # handle binary resources on disk
-        elif (self.origpath.startswith(config.dir) and
-              self.origpath.endswith('.binary')):
-            self.location = 'local'
-            self.type = 'binary'
-            self.relpath = self.origpath[len(config.dir):]
-            if not self.relpath.endswith('.binary'):
-                print('ERROR: Binary resource ' +
-                      '{0} lacks expected extension!'.format(self.origpath)
-                      )
-                self.logger.error('ERROR: Binary resource ' +
-                      '{0} lacks expected extension!'.format(self.origpath)
-                      )
-            self.destpath = config.repobase + self.relpath[:-len('.binary')]
-            self.sha1 = calculate_sha1(self.origpath)
-
-        # handle metadata resources on disk
-        elif (self.origpath.startswith(config.dir) and
-              self.origpath.endswith(config.ext)):
-            self.location = 'local'
-            self.type = 'rdf'
-            self.relpath = self.origpath[len(config.dir):]
-            if not self.relpath.endswith(config.ext):
-                print('ERROR: RDF resource ' +
-                      'lacks expected extension!'.format(self.origpath)
-                      )
-                self.logger.error('ERROR: RDF resource ' +
-                      'lacks expected extension!'.format(self.origpath)
-                      )
-            self.destpath = config.repobase + self.relpath[:-len(config.ext)]
-            self.graph = Graph().parse(location=self.origpath,
-                                       format=config.lang
-                                       )
+                self.destpath = quote(
+                    (self.config.dir + self.relpath + '.binary')
+                    )
+            self.lookup_sha1()
         else:
-            print("ERROR reading resource at {0}.".format(self.origpath))
-            self.logger.error("ERROR reading resource at {0}.".format(self.origpath))
-            sys.exit(1)
+            self.type = 'rdf'
+            self.destpath = quote(
+                (self.config.dir + self.relpath + self.config.ext)
+                )
+            response = requests.get(self.origpath, auth=self.config.auth)
+            if response.status_code == 200:
+                self.graph = Graph().parse(
+                    data=response.text, format="text/turtle"
+                    )
+    
+    def fetch_headers(self):
+        response = requests.head(url=self.origpath, auth=self.config.auth)
+        if response.status_code in [200, 307]:
+            self.headers = response.headers
+            self.ldp_type = response.links["type"]["url"]
+            if response.status_code == 200:
+                self.external = False
+            elif response.status_code == 307:
+                self.external = True
+            return True
+        else:
+            # handle other response codes appropriately here
+            return False
+    
+    def is_binary(self):
+        if self.headers:
+            if self.ldp_type == 'http://www.w3.org/ns/ldp#NonRDFSource':
+                return True
+            else:
+                return False
+    
+    def lookup_sha1(self):
+        self.metadata_node = self.origpath + '/fcr:metadata'
+        response = requests.get(self.metadata_node, auth=self.config.auth)
+        if response.status_code == 200:
+            m = search(
+                r'premis:hasMessageDigest <urn:sha1:(.+?)>', response.text
+                )
+            self.sha1 = m.group(1) if m else ""
+            return True
+
+#============================================================================
+# LOCAL RESOURCE CLASS
+#============================================================================
+
+class LocalResource(Resource):
+    '''Properties and methods for a resource serialized to disk.'''
+    def __init__(self, inputpath, config, logger):
+        Resource.__init__(self, inputpath, config, logger)
+        self.location = 'local'
+        self.relpath = self.origpath[len(config.dir):]
+        if self.is_binary():
+            self.type = 'binary'
+            self.destpath = config.repo + self.relpath[:-len('.binary')]
+            self.sha1 = self.calculate_sha1()
+        elif (self.origpath.startswith(config.dir) and 
+                    self.origpath.endswith(config.ext)):
+            self.type = 'rdf'
+            self.destpath = config.repo + self.relpath[:-len(config.ext)]
+            self.graph = Graph().parse(
+                location=self.origpath, format=config.lang
+                )
+        else:
+            print('ERROR: RDF resource ' +
+                'lacks expected extension!'.format(self.origpath)
+                )
+            self.logger.error('ERROR: RDF resource ' +
+                'lacks expected extension!'.format(self.origpath)
+                )
+
+    def is_binary(self):
+        if self.origpath.endswith('.binary') or \
+            self.origpath.endswith('.external'):
+            return True
+        else:
+            return False
+
+    def calculate_sha1(self):
+        with open(self.origpath, 'rb') as f:
+            sh = sha1()
+            while True:
+                data = f.read(8192)
+                if not data:
+                    break
+                sh.update(data)
+        return sh.hexdigest()
 
 #============================================================================
 # MAIN FUNCTION
@@ -353,98 +371,104 @@ def main():
     # Create configuration object and setup import/export iterators
     config = Config(args.configfile, args.user, logger)
     if config.mode == 'export':
-        trees = [FcrepoWalker(config.repo, args.user, logger)]
+        tree = FcrepoWalker(config.repo, args.user, logger)
     elif config.mode == 'import':
-        trees = [LocalWalker(config.dir, logger)]
+        tree = [LocalWalker(config.dir, logger)]
 
     logger.info("\nRunning verification on Fedora 4 {0}".format(config.mode))
     print("\nRunning verification on Fedora 4 {0}".format(config.mode))
 
     counter = 1
 
-    # Step through each iterator and verify resources
-    for walker in trees:
-        for filepath in walker:
-            if filepath is not None:
+    # Step through the tree and verify resources
+    
+    for filepath in tree:
+        # iterator can return None, in which case skip
+        if filepath is not None:
+            if filepath.startswith(config.repo):
+                original = FedoraResource(filepath, config, logger)
+            else:
+                original = LocalResource(filepath, config, logger)
+            
+            # skip binaries and fcr:metadata if no binaries exported
+            if not config.bin:
+                if original.type == "binary" or \
+                    original.origpath.endswith('/fcr:metadata'):
+                    continue
+            
+            if filepath.startswith(config.repo):
+                destination = LocalResource(original.destpath, config, logger)
+            else:
+                destination = FedoraResource(original.destpath, config, logger)
 
-                original = Resource(filepath, config, logger)
-                
-                # skip binaries and fcr:metadata if no binaries exported
-                if not config.bin:
-                    if original.type == "binary" or \
-                        original.origpath.endswith('/fcr:metadata'):
-                        continue
-                
-                destination = Resource(original.destpath, config, logger)
-
-                if original.type == 'binary':
-                    '''if destination.sha1 is None:
-                        verified = False
-                        verification = "external resource"'''
-                    if original.sha1 == destination.sha1:
-                        verified = True
-                        verification = original.sha1
-                    else:
-                        verified = False
-                        verification = "{0} != {1}".format(
-                            original.sha1, destination.sha1
-                            )
-
-                elif original.type == 'rdf':
-                    if isomorphic(original.graph, destination.graph):
-                        verified = True
-                        verification = "{0} triples".format(
-                                        len(original.graph)
-                                        )
-                    else:
-                        verified = False
-                        verification = ('{0}+{1} triples - mismatch'.format(
-                                            len(original.graph),
-                                            len(destination.graph)
-                                            ))
-
-                # always tell user if something doesn't match
-                if not verified:
-                    print('\nWARN: Resource Mismatch \'{}\''.format(original.relpath));
-
-                # If verbose flag is set, print full resource details to screen/file
-                if args.verbose:
-                    print("\nRESOURCE {0}: {1} {2}".format(
-                          counter, original.location, original.type
-                          ))
-                    print("  rel  => {}".format(original.relpath))
-                    print("  orig => {}".format(original.origpath))
-                    print("  dest => {}".format(original.destpath))
-                    print("  Verifying original to copy... {0} -- {1}".format(
-                         verified, verification))
+            if original.type == 'binary':
+                if destination.origpath.endswith('external'):
+                    verified = False
+                    verification = "external resource"
+                if original.sha1 == destination.sha1:
+                    verified = True
+                    verification = original.sha1
                 else:
-                    # Display a simple counter
-                    print("Checked {0} resources...".format(counter), end='\r')
+                    verified = False
+                    verification = "{0} != {1}".format(
+                        original.sha1, destination.sha1
+                        )
 
-                if not verified:
-                    logger.warn('\nWARN: Resource Mismatch \'{}\''.format(original.relpath));
-                    logger.info("RESOURCE {0}: {1} {2}".format(
-                          counter, original.location, original.type
-                          ))
+            elif original.type == 'rdf':
+                if isomorphic(original.graph, destination.graph):
+                    verified = True
+                    verification = "{0} triples".format(len(original.graph))
+                else:
+                    verified = False
+                    verification = ('{0}+{1} triples - mismatch'.format(
+                                        len(original.graph),
+                                        len(destination.graph)
+                                        ))
 
-                    logger.info("  rel  => {}".format(original.relpath))
-                    logger.info("  orig => {}".format(original.origpath))
-                    logger.info("  dest => {}".format(original.destpath))
-                    logger.info("  Verifying original to copy... {0} -- {1}".format(
-                         verified, verification))
+            # always tell user if something doesn't match
+            if not verified:
+                print('\nWARN: Resource Mismatch \'{}\''.format(original.relpath));
 
-                # If a CSV summary file has been specified, write results there
-                if args.csv:
-                    row = { 'number':       str(counter),
-                            'type':         original.type,
-                            'original':     original.origpath,
-                            'destination':  original.destpath,
-                            'verified':     str(verified),
-                            'verification': verification
-                            }
-                    writer.writerow(row)
+            # If verbose flag is set, print full resource details to screen/file
+            if args.verbose:
+                print("\nRESOURCE {0}: {1} {2}".format(
+                      counter, original.location, original.type
+                      ))
+                print("  rel  => {}".format(original.relpath))
+                print("  orig => {}".format(original.origpath))
+                print("  dest => {}".format(original.destpath))
+                print("  Verifying original to copy... {0} -- {1}".format(
+                    verified, verification
+                    ))
+            else:
+                # Display a simple counter
+                print("Checked {0} resources...".format(counter), end='\r')
 
-                counter += 1
+            if not verified:
+                logger.warn('\nWARN: Resource Mismatch \'{}\''.format(original.relpath));
+                logger.info("RESOURCE {0}: {1} {2}".format(
+                      counter, original.location, original.type
+                      ))
+
+                logger.info("  rel  => {}".format(original.relpath))
+                logger.info("  orig => {}".format(original.origpath))
+                logger.info("  dest => {}".format(original.destpath))
+                logger.info("  Verifying original to copy... {0} -- {1}".format(
+                    verified, verification
+                    ))
+
+            # If a CSV summary file has been specified, write results there
+            if args.csv:
+                row = { 'number':       str(counter),
+                        'type':         original.type,
+                        'original':     original.origpath,
+                        'destination':  original.destpath,
+                        'verified':     str(verified),
+                        'verification': verification
+                        }
+                writer.writerow(row)
+
+            counter += 1
 
     # Clear the resource counter display
     print('')

--- a/verify.py
+++ b/verify.py
@@ -231,7 +231,7 @@ class FedoraResource(Resource):
         response = requests.get(self.metadata, auth=self.config.auth)
         if response.status_code == 200:
             m = search(
-                r'premis:hasMessageDigest <urn:sha1:(.+?)>', response.text
+                r'premis:hasMessageDigest[\s]+<urn:sha1:(.+?)>', response.text
                 )
             self.sha1 = m.group(1) if m else ""
             return True


### PR DESCRIPTION
The main resource class has been split into three: a base class, and a sub-class for Fedora resources, and another for local resources.  This arrangement should be clearer and easier to maintain.

The tool now handles external binaries by checking for 307 redirects when walking Fedora (or the '.external' extension when walking the filesystem), and skips verification of those resources, since they are out of scope for import/export and verification. Metadata resources describing external binaries still get examined.