### PR TITLE
Retools the console and log output to improve usability.

### DIFF
--- a/fcrepo_verify/cli.py
+++ b/fcrepo_verify/cli.py
@@ -1,13 +1,8 @@
 import click
-from csv import DictWriter
 import logging
-import sys
-from datetime import datetime
-from rdflib.compare import isomorphic
 from fcrepo_verify.model import Config
-from fcrepo_verify.constants import EXT_BINARY_EXTERNAL
-from fcrepo_verify.iterators import FcrepoWalker, LocalWalker
-from fcrepo_verify.resources import FedoraResource, LocalResource
+from fcrepo_verify.loggers import createLoggers
+from fcrepo_verify.verifier import FedoraImportExportVerifier
 
 
 class CredentialsParamType(click.ParamType):
@@ -26,6 +21,7 @@ class CredentialsParamType(click.ParamType):
         except ValueError:
             self.fail('Credentials must be given in the form user:password.',
                       param, ctx)
+
 
 # ============================================================================
 # Main function
@@ -52,141 +48,11 @@ def main(configfile, csv, user, log, loglevel, verbose):
     """This utility compares two sets of Fedora resources
        (in live Fedora server or serialized to disk) and verify their sameness
        using CONFIGFILE (i.e. path to an import/export config file)."""
-    # click.echo('success!')
 
-    # Set up csv file, if specified
-    if csv:
-        csvfile = open(csv, "w")
-        fieldnames = ["number", "type", "original", "destination", "verified",
-                      "verification"]
-        writer = DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
-
-    # set up logging to a file
-    logger = logging.getLogger("output")
     level = getattr(logging, loglevel.upper(), None)
-    logger.setLevel(level)
-    fh = logging.FileHandler(filename=log, mode="w")
-    fh.setLevel(level)
-    logger.addHandler(fh)
-
-    logger.info("\nStarting verification: {}".format(datetime.now()))
+    loggers = createLoggers(level, log)
     # Create configuration object and setup import/export iterators
-    config = Config(configfile, user, logger)
-    if config.mode == "export":
-        tree = FcrepoWalker(config, logger)
-    elif config.mode == "import":
-        tree = LocalWalker(config, logger)
-
-    logger.info("\nRunning verification on Fedora 4 {0}".format(config.mode))
-    print("\nRunning verification on Fedora 4 {0}".format(config.mode))
-
-    counter = 0
-
-    # Step through the tree and verify resources
-    for filepath in tree:
-        # iterator can return None, in which case skip
-        if filepath is not None:
-            counter += 1
-            if filepath.startswith(config.repo):
-                original = FedoraResource(filepath, config, logger)
-            elif filepath.startswith(config.dir):
-                original = LocalResource(filepath, config, logger)
-            else:
-                logger.warn("Resource not in path specified in config file.")
-                sys.exit(1)
-
-            # skip binaries and fcr:metadata if no binaries exported
-            if not config.bin:
-                if original.type == "binary" or \
-                        original.origpath.endswith("/fcr:metadata"):
-                    continue
-
-            try:
-                if filepath.startswith(config.repo):
-                    destination = LocalResource(
-                        original.destpath, config, logger
-                        )
-                elif filepath.startswith(config.dir):
-                    destination = FedoraResource(
-                        original.destpath, config, logger
-                        )
-                if original.type == "binary":
-                    if destination.origpath.endswith(EXT_BINARY_EXTERNAL):
-                        verified = False
-                        verification = "external resource"
-                    if original.sha1 == destination.sha1:
-                        verified = True
-                        verification = original.sha1
-                    else:
-                        verified = False
-                        verification = "{0} != {1}".format(
-                            original.sha1, destination.sha1
-                            )
-                elif original.type == "rdf":
-                    if isomorphic(original.graph, destination.graph):
-                        verified = True
-                        verification = "{0} triples".format(
-                            len(original.graph)
-                            )
-                    else:
-                        verified = False
-                        verification = ("{0}+{1} triples - mismatch".format(
-                                            len(original.graph),
-                                            len(destination.graph)
-                                            ))
-            except FileNotFoundError:
-                verified = False
-                verification = "destination file not found"
-
-            # always tell user if something doesn't match
-            if not verified:
-                print("\nWARN: Resource Mismatch \"{}\"".format(
-                    original.relpath))
-
-            # If verbose flag is set, print full resource details to
-            # screen/file
-            if verbose:
-                print("\nRESOURCE {0}: {1} {2}".format(
-                      counter, original.location, original.type
-                      ))
-                print("  rel  => {}".format(original.relpath))
-                print("  orig => {}".format(original.origpath))
-                print("  dest => {}".format(original.destpath))
-                print("  Verifying original to copy... {0} -- {1}".format(
-                    verified, verification
-                    ))
-            else:
-                # Display a simple counter
-                print("Checked {0} resources...".format(counter), end="\r")
-
-            if not verified:
-                logger.warn("\nWARN: Resource Mismatch \"{}\"".format(
-                    original.relpath))
-                logger.info("RESOURCE {0}: {1} {2}".format(
-                      counter, original.location, original.type
-                      ))
-
-                logger.info("  rel  => {}".format(original.relpath))
-                logger.info("  orig => {}".format(original.origpath))
-                logger.info("  dest => {}".format(original.destpath))
-                logger.info(
-                        "  Verifying original to copy... {0} -- {1}"
-                        .format(verified, verification))
-
-            # If a CSV summary file has been specified, write results there
-            if csv:
-                row = {"number":       str(counter),
-                       "type":         original.type,
-                       "original":     original.origpath,
-                       "destination":  original.destpath,
-                       "verified":     str(verified),
-                       "verification": verification}
-                writer.writerow(row)
-
-    # Clear the resource counter display
-    print("")
-    logger.info("Verified {} resources".format(counter))
-
-    if csv:
-        csvfile.close()
+    config = Config(configfile, user, loggers, csv, verbose)
+    # Create and execute verifier logic
+    verifier = FedoraImportExportVerifier(config, loggers)
+    verifier.execute()

--- a/fcrepo_verify/loggers.py
+++ b/fcrepo_verify/loggers.py
@@ -1,0 +1,55 @@
+import logging
+
+
+class Loggers:
+    def __init__(self, console, console_only, file_only):
+        self.console = console
+        self.console_only = console_only
+        self.file_only = file_only
+
+
+def createLoggers(level, logfilename):
+    '''Creates and configures a Loggers object which contains three loggers:
+        console - logs to both the console and the log file
+        console_only - logs only to the console
+        file_only - only logs to the file'''
+
+    # create console logger
+    console = logging.getLogger("output")
+    console.setLevel(level)
+
+    # create console handler and set level to debug
+    console_handler = logging.StreamHandler()
+    file_handler = logging.FileHandler(filename=logfilename, mode="w")
+
+    # set level
+    # console_handler.setLevel(logging.INFO)
+    # file_handler.setLevel(logging.DEBUG)
+
+    # create formatters
+    console_formatter = logging.Formatter("%(asctime)s %(levelname)-8s "
+                                          "%(message)s")
+    file_formatter = logging.Formatter("%(asctime)s %(levelname)-8s "
+                                       "%(module)-12s : %(lineno)d =>  "
+                                       "%(message)s")
+
+    # add formatter to console_handler
+    console_handler.setFormatter(console_formatter)
+    file_handler.setFormatter(file_formatter)
+    # add console_handler to logger
+    console.addHandler(console_handler)
+    console.addHandler(file_handler)
+
+    # create console only logger
+    console_only = logging.getLogger("console_only")
+    console_only.setLevel(logging.DEBUG)
+    console_only.addHandler(console_handler)
+
+    # create file only logger
+    file_only = logging.getLogger("file_only")
+    file_only.setLevel(level)
+    file_only.addHandler(file_handler)
+
+    loggers = Loggers(console, console_only, file_only)
+
+    return loggers

--- a/fcrepo_verify/model.py
+++ b/fcrepo_verify/model.py
@@ -17,10 +17,13 @@ except ImportError:
 class Config():
     """Object representing the options from import/export config and
        command-line arguments."""
-    def __init__(self, configfile, auth, logger):
-        logger.info("\nLoading configuration options from config file:")
-        logger.info("  '{0}'".format(configfile))
+    def __init__(self, configfile, auth, loggers, csv, verbose):
+        console = loggers.console
+        console.info("\nLoading configuration options from config file:")
+        console.info("  '{0}'".format(configfile))
         self.auth = auth
+        self.csv = csv
+        self.verbose = verbose
 
         with open(configfile, "r") as f:
             yaml_data = f.read()
@@ -52,9 +55,7 @@ class Config():
             if self.lang in EXT_MAP:
                 self.ext = EXT_MAP[self.lang]
             else:
-                logger.error(
-                    "Unrecognized RDF serialization specified in config file!")
-                print(
+                loggers.console.error(
                     "Unrecognized RDF serialization specified in config file!")
                 sys.exit(1)
 

--- a/fcrepo_verify/verifier.py
+++ b/fcrepo_verify/verifier.py
@@ -1,0 +1,154 @@
+from csv import DictWriter
+import sys
+import time
+import threading
+from rdflib.compare import isomorphic
+
+from fcrepo_verify.constants import EXT_BINARY_EXTERNAL
+from fcrepo_verify.iterators import FcrepoWalker, LocalWalker
+from fcrepo_verify.resources import FedoraResource, LocalResource
+
+
+class FedoraImportExportVerifier:
+    """contains logic for performing a verification"""
+
+    def __init__(self, config, loggers):
+        self.config = config
+        self.loggers = loggers
+
+    def execute(self):
+        """executes the verification process"""
+        config = self.config
+        csv = self.config.csv
+
+        loggers = self.loggers
+        logger = loggers.file_only
+        console = loggers.console
+        console_only = loggers.console_only
+
+        # Set up csv file, if specified
+        if csv:
+            csvfile = open(csv, "w")
+            fieldnames = ["number", "type", "original", "destination",
+                          "verified",
+                          "verification"]
+            writer = DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+
+        console.info("Starting verification...")
+        if config.mode == "export":
+            tree = FcrepoWalker(config, logger)
+        elif config.mode == "import":
+            tree = LocalWalker(config, logger)
+
+        console.info("Running verification on Fedora 4 {0}"
+                     .format(config.mode))
+
+        success_count = 0
+        failure_count = 0
+
+        def total_count():
+            return success_count + failure_count
+
+        def log_summary(logger):
+            logger.info(
+                "Verified {} resources:  successes = {},  failures={}"
+                .format(total_count(), success_count, failure_count))
+
+        def count_logger():
+            while(True):
+                time.sleep(10)
+                log_summary(console_only)
+
+        t = threading.Thread(target=count_logger)
+        t.daemon = True
+        t.start()
+
+        # Step through the tree and verify resources
+        for filepath in tree:
+            # iterator can return None, in which case skip
+            if filepath is not None:
+
+                if filepath.startswith(config.repo):
+                    original = FedoraResource(filepath, config, logger)
+                elif filepath.startswith(config.dir):
+                    original = LocalResource(filepath, config, logger)
+                else:
+                    logger.warn(
+                        "Resource not in path specified in config file.")
+                    sys.exit(1)
+
+                # skip binaries and fcr:metadata if no binaries exported
+                if not config.bin:
+                    if original.type == "binary" or \
+                            original.origpath.endswith("/fcr:metadata"):
+                        continue
+
+                if filepath.startswith(config.repo):
+                    destination = LocalResource(original.destpath,
+                                                config,
+                                                loggers.file_only)
+                elif filepath.startswith(config.dir):
+                    destination = FedoraResource(original.destpath,
+                                                 config,
+                                                 loggers.file_only)
+
+                if original.type == "binary":
+                    if destination.origpath.endswith(EXT_BINARY_EXTERNAL):
+                        verified = False
+                        verification = "external resource"
+                    if original.sha1 == destination.sha1:
+                        verified = True
+                        verification = original.sha1
+                    else:
+                        verified = False
+                        verification = "{0} != {1}".format(
+                            original.sha1, destination.sha1
+                            )
+
+                elif original.type == "rdf":
+                    if isomorphic(original.graph, destination.graph):
+                        verified = True
+                        verification = \
+                            "{0} triples".format(len(original.graph))
+                    else:
+                        verified = False
+                        verification = ("{0}+{1} triples - mismatch".format(
+                                            len(original.graph),
+                                            len(destination.graph)
+                                            ))
+
+                logger.info("RESOURCE {0}: {1} {2}".format(
+                      total_count(), original.location, original.type
+                      ))
+
+                if not verified:
+                    logger.warn("Resource Mismatch \"{}\"".format(
+                        original.relpath))
+                    failure_count += 1
+                else:
+                    success_count += 1
+
+                if config.verbose:
+                    logger.info("  rel  => {}".format(original.relpath))
+                    logger.info("  orig => {}".format(original.origpath))
+                    logger.info("  dest => {}".format(original.destpath))
+                    logger.info(
+                            "  Verifying original to copy... {0} -- {1}"
+                            .format(verified, verification))
+
+                # write csv if exists
+                if csv:
+                    row = {"number":       str(total_count()),
+                           "type":         original.type,
+                           "original":     original.origpath,
+                           "destination":  original.destpath,
+                           "verified":     str(verified),
+                           "verification": verification}
+                    writer.writerow(row)
+
+        log_summary(console)
+        console.info("Verification complete")
+
+        if csv:
+            csvfile.close()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = ['click',
 
 setup(
     name='fcrepo-verify',
-    version='0.1.0',
+    version='0.2.0-SNAPSHOT',
     url='https://github.com/dbernstein/fcrepo-import-export-verify',
     license='Apache',
     author='Josh Westgard, Bethany Seeger, Youn Noh, Daniel Bernstein',


### PR DESCRIPTION
Now standard out prints runtime summary of the tool every 10 seconds showing a running count of successes and failures.

File-based log includes everything from standard out except the periodic summary updates as well as  all log messages in accordance with the specified log level and the state of the --verbose flag.

All log messages include timestamps,  message level. The file log also contains file and line information in addition to messages for easier debugging.

Resolves https://jira.duraspace.org/browse/FCREPO-2368