### PR TITLE
A little housekeeping:

### DIFF
--- a/fcrepo_verify/cli.py
+++ b/fcrepo_verify/cli.py
@@ -56,3 +56,7 @@ def main(configfile, csv, user, log, loglevel, verbose):
     # Create and execute verifier logic
     verifier = FedoraImportExportVerifier(config, loggers)
     verifier.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/fcrepo_verify/iterators.py
+++ b/fcrepo_verify/iterators.py
@@ -1,7 +1,5 @@
-__author__ = 'danny'
-
 from os.path import basename, isfile
-from fcrepo_verify.utils import get_directory_contents, get_child_nodes
+from .utils import get_directory_contents, get_child_nodes
 
 
 class Walker:

--- a/fcrepo_verify/model.py
+++ b/fcrepo_verify/model.py
@@ -1,9 +1,7 @@
-__author__ = 'danny'
-
 import requests
 import sys
 from urllib.parse import urlparse
-from fcrepo_verify.constants import EXT_MAP
+from .constants import EXT_MAP
 from yaml import load
 try:
     from yaml import CLoader as Loader
@@ -31,7 +29,7 @@ class Config():
         self.bin = False
         # interpret the options in the stored config file
         for key, value in opts.items():
-            print("key (" + str(key) + ") and (" + str(value) + ")")
+            console.info("key (" + str(key) + ") and (" + str(value) + ")")
             if key == "mode":
                 self.mode = value
             elif key == "resource":

--- a/fcrepo_verify/resources.py
+++ b/fcrepo_verify/resources.py
@@ -5,8 +5,8 @@ from re import search
 import requests
 from urllib.parse import urlparse, quote
 
-from fcrepo_verify.constants import EXT_BINARY_INTERNAL, \
-    EXT_BINARY_EXTERNAL, LDP_NON_RDF_SOURCE
+from .constants import EXT_BINARY_INTERNAL, EXT_BINARY_EXTERNAL, \
+    LDP_NON_RDF_SOURCE
 
 
 class Resource(object):
@@ -105,10 +105,9 @@ class LocalResource(Resource):
                 location=self.origpath, format=config.lang
                 )
         else:
-            msg = "ERROR: RDF resource lacks expected extension!".format(
+            msg = "RDF resource lacks expected extension!".format(
                     self.origpath)
 
-            print(msg)
             self.logger.error(msg)
 
     def is_binary(self):

--- a/fcrepo_verify/utils.py
+++ b/fcrepo_verify/utils.py
@@ -1,6 +1,4 @@
-__author__ = 'danny'
-
-from fcrepo_verify.constants import LDP_CONTAINS, LDP_NON_RDF_SOURCE
+from .constants import LDP_CONTAINS, LDP_NON_RDF_SOURCE
 from rdflib import Graph, URIRef
 import requests
 import sys

--- a/fcrepo_verify/verifier.py
+++ b/fcrepo_verify/verifier.py
@@ -4,10 +4,10 @@ import time
 import threading
 from rdflib.compare import isomorphic
 
-from fcrepo_verify.constants import EXT_BINARY_EXTERNAL
-from fcrepo_verify.iterators import FcrepoWalker, LocalWalker
-from fcrepo_verify.resources import FedoraResource, LocalResource
-from fcrepo_verify.model import Repository
+from .constants import EXT_BINARY_EXTERNAL
+from .iterators import FcrepoWalker, LocalWalker
+from .resources import FedoraResource, LocalResource
+from .model import Repository
 
 
 class FedoraImportExportVerifier:


### PR DESCRIPTION
 * Removes auto generated author line and replaces stray "print" statements with calls to the appropriate logger.
 * Adds a __main__ entry point for cli class to facilitate debugging.
 * Use more abbreviated import syntax.