### PR TITLE
Verification tool now timestamps logs and csv reports and places them in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,5 @@ ENV/
 .idea/
 
 # verify output
-verify_output.txt
-verify_summary.txt
+logs/
+output/

--- a/fcrepo_verify/cli.py
+++ b/fcrepo_verify/cli.py
@@ -26,14 +26,16 @@ class CredentialsParamType(click.ParamType):
 
 
 @click.command()
-@click.option('--csv', '-c', help='Path to CSV file (to store summary data).',
-              default='verify_summary.txt')
+@click.option('--outputdir', '-o', help='Path to director for output files '
+                                        'such as csv reports of the '
+                                        'verification process.',
+              default='output')
 @click.option('--user', '-u',
               help='Repository credentials in the form of username:password',
               type=CredentialsParamType(), default=None)
-@click.option('--log', '-l',
+@click.option('--logdir', '-l',
               help='Path to log file (to store details of verification run).',
-              default='verify_output.txt')
+              default='logs')
 @click.option('--loglevel', '-g',
               help='Level of information to output (INFO, WARN, DEBUG, ERROR)',
               default='INFO')
@@ -41,7 +43,7 @@ class CredentialsParamType(click.ParamType):
               help='Show detailed info for each resource checked',
               is_flag=True, default=False)
 @click.argument('configfile', type=click.Path(exists=True), required=True)
-def main(configfile, csv, user, log, loglevel, verbose):
+def main(configfile, outputdir, user, logdir, loglevel, verbose):
     """Verify that the resources in Fedora and on disk are the same.
 
     Using a CONFIGFILE (i.e. path to an fcrepo-import-export configuration
@@ -50,9 +52,10 @@ def main(configfile, csv, user, log, loglevel, verbose):
     are the same.
     """
     level = getattr(logging, loglevel.upper(), None)
-    loggers = createLoggers(level, log)
+    loggers = createLoggers(level, logdir)
     # Create configuration object and setup import/export iterators
-    config = Config(configfile, user, loggers, csv, verbose)
+    csv = None
+    config = Config(configfile, user, loggers, outputdir, verbose)
     # Create and execute verifier logic
     verifier = FedoraImportExportVerifier(config, loggers)
     verifier.execute()

--- a/fcrepo_verify/cli.py
+++ b/fcrepo_verify/cli.py
@@ -26,7 +26,7 @@ class CredentialsParamType(click.ParamType):
 
 
 @click.command()
-@click.option('--outputdir', '-o', help='Path to director for output files '
+@click.option('--outputdir', '-o', help='Path to directory for output files '
                                         'such as csv reports of the '
                                         'verification process.',
               default='output')

--- a/fcrepo_verify/cli.py
+++ b/fcrepo_verify/cli.py
@@ -53,8 +53,8 @@ def main(configfile, outputdir, user, logdir, loglevel, verbose):
     """
     level = getattr(logging, loglevel.upper(), None)
     loggers = createLoggers(level, logdir)
+
     # Create configuration object and setup import/export iterators
-    csv = None
     config = Config(configfile, user, loggers, outputdir, verbose)
     # Create and execute verifier logic
     verifier = FedoraImportExportVerifier(config, loggers)

--- a/fcrepo_verify/loggers.py
+++ b/fcrepo_verify/loggers.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import datetime
 
 
 class Loggers:
@@ -8,7 +10,7 @@ class Loggers:
         self.file_only = file_only
 
 
-def createLoggers(level, logfilename):
+def createLoggers(level, log_dir):
     """Creates and configures Loggers object containing three loggers.
 
     The Loggers object contains these loggers:
@@ -17,6 +19,10 @@ def createLoggers(level, logfilename):
         file_only - only logs to the file
     """
 
+    os.makedirs(log_dir, exist_ok=True)
+    datestr = datetime.datetime.today().strftime('%Y%m%d-%H%M')
+    logfilename = "{0}/verify-{1}.log".format(log_dir, datestr)
+
     # create console logger
     console = logging.getLogger("output")
     console.setLevel(level)
@@ -24,10 +30,6 @@ def createLoggers(level, logfilename):
     # create console handler and set level to debug
     console_handler = logging.StreamHandler()
     file_handler = logging.FileHandler(filename=logfilename, mode="w")
-
-    # set level
-    # console_handler.setLevel(logging.INFO)
-    # file_handler.setLevel(logging.DEBUG)
 
     # create formatters
     console_formatter = logging.Formatter("%(asctime)s %(levelname)-8s "

--- a/fcrepo_verify/model.py
+++ b/fcrepo_verify/model.py
@@ -11,13 +11,13 @@ except ImportError:
 
 class Config():
     """Object representing the options from configuration file and args."""
-    def __init__(self, configfile, auth, loggers, csv, verbose):
+    def __init__(self, configfile, auth, loggers, output_dir, verbose):
         console = loggers.console
         console.info(
             "Loading configuration options from {0}".format(configfile)
             )
         self.auth = auth
-        self.csv = csv
+        self.output_dir = output_dir
         self.verbose = verbose
         self.bag = False
 


### PR DESCRIPTION
configurable directories (logs and output respectively by default) to
prevent overwriting of previous runs.

Resolves: https://jira.duraspace.org/browse/FCREPO-2475